### PR TITLE
Add extension in importing component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import tinymce from './components/TinymceVue'
+import tinymce from './components/TinymceVue.vue'
 
 export default tinymce
 export { tinymce }


### PR DESCRIPTION
Vite don't support importing vue files without the extension